### PR TITLE
feat(optimized-blob-coder): Implement custom OptimizedBlobCoder

### DIFF
--- a/src/bin/rpc_send_blob_segment.rs
+++ b/src/bin/rpc_send_blob_segment.rs
@@ -1,10 +1,9 @@
 use alloy_primitives::hex::ToHexExt;
-use alloy_primitives::{keccak256, Bytes, U128};
+use alloy_primitives::{Bytes, U128};
 use blobsy_aggregator::rpc::serialize::RawBlobSegment;
 use jsonrpsee::core::client::ClientT;
 use jsonrpsee::http_client::HttpClientBuilder;
-use std::any::Any;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::time::sleep;
 use tracing::{debug, error};
 
@@ -22,8 +21,8 @@ async fn main() -> eyre::Result<()> {
     // Crate and send new blob segment every [timeout] seconds
     let timeout = Duration::from_secs(12);
     loop {
-        /// The [epoch_timestamp] ensures each blob segment is unique.
-        /// To send duplicate segments, use a fixed timestamp value instead of the current time.
+        // The [epoch_timestamp] ensures each blob segment is unique.
+        // To send duplicate segments, use a fixed timestamp value instead of the current time.
         let now = SystemTime::now();
         let epoch_timestamp = now.duration_since(UNIX_EPOCH)?.as_secs();
         let data = format!("RPC_SEND_BLOB_SEGMENT [timestamp: {}]", epoch_timestamp).encode_hex();

--- a/src/bin/run_blob_aggregator.rs
+++ b/src/bin/run_blob_aggregator.rs
@@ -1,5 +1,4 @@
 use alloy_primitives::address;
-use alloy_rpc_types_eth::pubsub::SubscriptionKind::NewHeads;
 use alloy_signer_local::PrivateKeySigner;
 use blobsy_aggregator::building::blob_aggregator::BlobAggregator;
 use blobsy_aggregator::chain::new_heads_subscription::NewHeadsSubscription;

--- a/src/building/appending_blob_aggregator.rs
+++ b/src/building/appending_blob_aggregator.rs
@@ -101,7 +101,9 @@ impl AppendingBlobAggregator {
                     new_data.extend_from_slice(&segment.blob_segment_data.clone());
                     let new_data_bytes = Bytes::from(new_data);
 
-                    new_partial_blobs.push(PartialBlob::new(new_segments, new_data_bytes));
+                    let new_total_fee = partial_blob.total_fee() + segment.max_blob_segment_fee;
+
+                    new_partial_blobs.push(PartialBlob::new(new_segments, new_data_bytes, new_total_fee));
 
                     appended = true
                 }
@@ -112,6 +114,7 @@ impl AppendingBlobAggregator {
                     new_partial_blobs.push(PartialBlob::new(
                         vec![segment.clone()],
                         segment.blob_segment_data.clone(),
+                        0,
                     ));
                 }
 
@@ -120,7 +123,7 @@ impl AppendingBlobAggregator {
 
                 // Send the latest partial blobs state to the RPC submitter
                 debug!("Send latest Appending Blob Aggregator state");
-                partial_blobs_sender.send(new_partial_blobs).await;
+                let _ = partial_blobs_sender.send(new_partial_blobs).await;
             }
         }
     }

--- a/src/building/partial_blob.rs
+++ b/src/building/partial_blob.rs
@@ -1,16 +1,18 @@
 use crate::primitives::blob_segment::BlobSegment;
+use crate::submission::optimized_blob_coder::OptimizedBlobCoder;
 use alloy_eips::eip4844::USABLE_BYTES_PER_BLOB;
 use alloy_primitives::Bytes;
-use crate::submission::optimized_blob_coder::OptimizedBlobCoder;
+use std::cmp::Ordering;
 
 /// Intermediary blob structure for appending blob segments. Upon submission partial blobs are sealed
 /// and submitted as a full blob.
 ///
 /// NOTE: Make struct contents private to make PartialBlob immutable on the outside.
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PartialBlob {
     segments: Vec<BlobSegment>,
     data: Bytes,
+    total_fee: u128,
 }
 
 impl PartialBlob {
@@ -19,8 +21,13 @@ impl PartialBlob {
     /// # Arguments
     /// * `segments` - Blob segments to initialize new `PartialBlob` with
     /// * `data` - Blob data to initialize new `PartialBlob` with
-    pub fn new(segments: Vec<BlobSegment>, data: Bytes) -> Self {
-        Self { segments, data }
+    /// * `total_fee` - Total fee the blob segments are willing to pay
+    pub fn new(segments: Vec<BlobSegment>, data: Bytes, total_fee: u128) -> Self {
+        Self {
+            segments,
+            data,
+            total_fee,
+        }
     }
 
     /// Check if the blob segment can be appended to the current blob
@@ -39,5 +46,75 @@ impl PartialBlob {
     /// Return blob data in the current partial blob
     pub fn data(&self) -> &Bytes {
         &self.data
+    }
+
+    /// Return total fee the blob segments are willing to pay
+    pub fn total_fee(&self) -> u128 {
+        self.total_fee
+    }
+}
+
+// Implement custom DESCENDING ordering by total_fee for PartialBlob
+impl Ord for PartialBlob {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other.total_fee.cmp(&self.total_fee)
+    }
+
+    fn max(self, other: Self) -> Self
+    where
+        Self: Sized,
+    {
+        if self.total_fee >= other.total_fee {
+            self
+        } else {
+            other
+        }
+    }
+
+    fn min(self, other: Self) -> Self
+    where
+        Self: Sized,
+    {
+        if self.total_fee <= other.total_fee {
+            self
+        } else {
+            other
+        }
+    }
+
+    fn clamp(self, min: Self, max: Self) -> Self
+    where
+        Self: Sized,
+        Self: PartialOrd,
+    {
+        if self.total_fee < min.total_fee {
+            min
+        } else if self.total_fee > max.total_fee {
+            max
+        } else {
+            self
+        }
+    }
+}
+
+impl PartialOrd for PartialBlob {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+
+    fn lt(&self, other: &Self) -> bool {
+        self.total_fee < other.total_fee
+    }
+
+    fn le(&self, other: &Self) -> bool {
+        self.total_fee <= other.total_fee
+    }
+
+    fn gt(&self, other: &Self) -> bool {
+        self.total_fee > other.total_fee
+    }
+
+    fn ge(&self, other: &Self) -> bool {
+        self.total_fee >= other.total_fee
     }
 }

--- a/src/building/partial_blob.rs
+++ b/src/building/partial_blob.rs
@@ -1,6 +1,7 @@
 use crate::primitives::blob_segment::BlobSegment;
 use alloy_eips::eip4844::USABLE_BYTES_PER_BLOB;
 use alloy_primitives::Bytes;
+use crate::submission::optimized_blob_coder::OptimizedBlobCoder;
 
 /// Intermediary blob structure for appending blob segments. Upon submission partial blobs are sealed
 /// and submitted as a full blob.
@@ -24,7 +25,10 @@ impl PartialBlob {
 
     /// Check if the blob segment can be appended to the current blob
     pub fn can_append_segment(&self, segment_data: &Bytes) -> bool {
-        self.data.len() + segment_data.len() < USABLE_BYTES_PER_BLOB
+        let mut segment_len = segment_data.len();
+        segment_len += OptimizedBlobCoder::LENGTH_PREFIX_SIZE_BYTES;
+
+        self.data.len() + segment_len < USABLE_BYTES_PER_BLOB
     }
 
     /// Return blob segments in the current partial blob

--- a/src/submission/mod.rs
+++ b/src/submission/mod.rs
@@ -1,2 +1,2 @@
-pub mod optimized_coder;
+pub mod optimized_blob_coder;
 pub mod rpc_submitter;

--- a/src/submission/optimized_blob_coder.rs
+++ b/src/submission/optimized_blob_coder.rs
@@ -1,0 +1,451 @@
+use alloy_eips::eip4844::builder::{PartialSidecar, SidecarCoder};
+use alloy_eips::eip4844::utils::WholeFe;
+use alloy_eips::eip4844::{Blob, FIELD_ELEMENT_BYTES_USIZE, USABLE_BITS_PER_FIELD_ELEMENT};
+use alloy_primitives::hex::ToHexExt;
+
+/// Optimized BLOB coder that uses up to 254 bits (31.75 bytes) of each field element.
+///
+/// This coder maximizes storage efficiency by using:
+/// - The lower 254 bits of each field element (31.75 bytes)
+/// - The top 2 bits of each field element must remain 0 to preserve EIP-4844 KZG commitment requirements
+///
+///         The BLS12-381 scalar field (used in KZG commitments) has a modulus close to 2^255.
+///         However, it is not exactly 2^255, so the top 2 bits of the field element must be 0.
+///         This ensures the field element remains valid.
+///
+/// Encoding process:
+/// - Before encoding data, the HEADER (blob coder identifier) is encoded into the first field element of the first blob
+/// - Data is OPTIONALLY pre-pended with a 32-bit (4 bytes) big-endian length prefix
+/// - Data is converted to a bitstream and packed into consecutive field elements
+/// - Each field element stores up to 254 bits of the stream
+/// - The last field element is padded with zeros if needed
+#[derive(Clone, Copy, Debug, Default)]
+pub struct OptimizedBlobCoder {
+    prepend_length: bool,
+
+    header_prepended: bool,
+}
+
+impl OptimizedBlobCoder {
+    const UNALLOCATED_BITS_PER_FE: usize = 256 - USABLE_BITS_PER_FIELD_ELEMENT;
+    const LENGTH_PREFIX_BITS: usize = 32;
+
+    /// Create a new instance of `OptimizedCoder`.
+    pub fn new(prepend_length: bool) -> Self {
+        Self {
+            prepend_length,
+            header_prepended: false,
+        }
+    }
+
+    /// Get the name of the coder.
+    const fn get_name(&self) -> &'static str {
+        const NAME: &str = "OptimizedCoder(pl=true)";
+        const _: () = assert!(
+            NAME.len() < FIELD_ELEMENT_BYTES_USIZE,
+            "Coder name must fit into 31 bytes (so it's encoded as one FE)"
+        );
+        NAME
+    }
+
+    /// Decode a single piece of data from an iterator of valid field elements.
+    ///
+    /// Returns `Ok(Some(data))` if there is data.
+    /// Returns `Ok(None)` if there is no data (empty iterator, length prefix is 0).
+    /// Returns `Err(())` if there is an error.
+    fn decode_one<'a, I>(&self, iter: &mut I) -> Result<Option<Vec<u8>>, ()>
+    where
+        I: Iterator<Item = WholeFe<'a>> + Clone,
+    {
+        let Some(first) = iter.next() else {
+            return Ok(None);
+        };
+
+        let mut fes = Vec::new();
+        fes.push(first.as_ref().try_into().unwrap());
+
+        // Convert field elements to bits
+        let bits = Self::field_elements_to_bits(&fes);
+
+        // Set up initial values
+        const MAX_ALLOCATION_SIZE: usize = 2_097_152; // 2 MiB
+        let mut num_bytes = 0;
+        let mut start_bit = 0;
+
+        // Read data length
+        if self.prepend_length {
+            // Extract length prefix (32 bits)
+            let length_bits = &bits[0..Self::LENGTH_PREFIX_BITS];
+            let length_bytes = Self::bits_to_bytes(length_bits);
+            num_bytes = u32::from_be_bytes(length_bytes.try_into().unwrap()) as usize;
+            start_bit = Self::LENGTH_PREFIX_BITS;
+        } else {
+            // If no length prefix, we assume the data is the entire blob
+            // Increase fe_count by +1 to account already consumed first FE
+            let fe_count = iter.clone().count() + 1;
+            num_bytes = fe_count * FIELD_ELEMENT_BYTES_USIZE;
+
+            // Subtract unallocated bits from the total number of bytes
+            let unallocated_bits_count = fe_count * Self::UNALLOCATED_BITS_PER_FE;
+            num_bytes -= unallocated_bits_count.div_ceil(8);
+        }
+
+        // If length is 0, we're done
+        if num_bytes == 0 {
+            return Ok(None);
+        }
+
+        // Limit allocation size for safety
+        if num_bytes > MAX_ALLOCATION_SIZE {
+            return Err(());
+        }
+
+        // Calculate how many more bits we need
+        let bits_needed = num_bytes * 8;
+        let mut bits_already_have = bits.len();
+
+        // Subtract length prefix bits (if any)
+        if self.prepend_length {
+            bits_already_have = bits_already_have - Self::LENGTH_PREFIX_BITS;
+        }
+
+        // Calculate how many more field elements we need
+        let additional_bits_needed = bits_needed.saturating_sub(bits_already_have);
+        let additional_fes_needed = additional_bits_needed.div_ceil(USABLE_BITS_PER_FIELD_ELEMENT);
+
+        // Collect the remaining field elements
+        for _ in 0..additional_fes_needed {
+            let fe = iter.next();
+            if !fe.is_some() {
+                // If we run out of field elements, stop processing
+                break;
+            }
+            fes.push(fe.unwrap().as_ref().try_into().unwrap());
+        }
+
+        // Re-extract all bits now that we have enough field elements
+        let all_bits = Self::field_elements_to_bits(&fes);
+
+        // Take data bits (after the length prefix) and convert back to bytes
+        let data_bits = &all_bits[start_bit..(start_bit + bits_needed)];
+        let data = Self::bits_to_bytes(data_bits);
+
+        Ok(Some(data))
+    }
+
+    /// Convert bytes to a bit array
+    fn bytes_to_bits(bytes: &[u8]) -> Vec<bool> {
+        let mut bits = Vec::with_capacity(bytes.len() * 8);
+
+        for &byte in bytes {
+            // Iterate over each bit in the byte, from MSB (Most Significant Bit) to LSB (Lest Significant Bit)
+            for i in (0..8).rev() {
+                // Extract and push the bit
+                bits.push((byte >> i) & 1 == 1);
+            }
+        }
+
+        bits
+    }
+
+    /// Convert bits to bytes
+    fn bits_to_bytes(bits: &[bool]) -> Vec<u8> {
+        let byte_count = bits.len().div_ceil(8);
+        let mut bytes = vec![0u8; byte_count];
+
+        for (i, &bit) in bits.iter().enumerate() {
+            if bit {
+                // Get byte index and bit position, to flip the correct bit
+                let byte_idx = i / 8;
+                let bit_pos = 7 - (i % 8); // MSB (Most Significant Bit) ordering
+
+                // Flip the bit to 1
+                bytes[byte_idx] |= 1 << bit_pos;
+            }
+        }
+
+        bytes
+    }
+
+    /// Convert bitstream to field elements
+    fn bits_to_field_elements(bits: &[bool]) -> Vec<[u8; 32]> {
+        let mut result = Vec::new();
+
+        // Process the bits in chunks of 254 bits (31.75 bytes)
+        let start_bit = Self::UNALLOCATED_BITS_PER_FE; // Skip the top 2 bits in each FE, as per KZG commitment requirements
+        for chunk in bits.chunks(USABLE_BITS_PER_FIELD_ELEMENT) {
+            let mut fe = [0u8; FIELD_ELEMENT_BYTES_USIZE];
+
+            // Process each bit in the chunk
+            for (i, &bit) in chunk.iter().enumerate() {
+                if bit {
+                    // Calculate byte index (0-31) and bit position (0-7)
+                    let byte_idx = (start_bit + i) / 8;
+                    let bit_pos = 7 - ((start_bit + i) % 8); // MSB (Most Significant Bit) ordering
+
+                    // Flip the bit to 1
+                    fe[byte_idx] |= 1 << bit_pos;
+                }
+            }
+
+            result.push(fe);
+        }
+
+        result
+    }
+
+    /// Extract bits from field elements
+    fn field_elements_to_bits(fes: &[[u8; 32]]) -> Vec<bool> {
+        let mut bits = Vec::with_capacity(fes.len() * USABLE_BITS_PER_FIELD_ELEMENT);
+
+        for fe in fes {
+            // Process each byte of the field element
+            for (byte_idx, &byte) in fe.iter().enumerate() {
+                // For the first byte, only use the lower 2 bits
+                let start_bit = if byte_idx == 0 {
+                    Self::UNALLOCATED_BITS_PER_FE
+                } else {
+                    0
+                };
+
+                // Extract bits from the byte
+                for bit_pos in start_bit..8 {
+                    bits.push((byte >> (7 - bit_pos)) & 1 == 1);
+                }
+            }
+        }
+
+        bits
+    }
+}
+
+impl SidecarCoder for OptimizedBlobCoder {
+    fn required_fe(&self, data: &[u8]) -> usize {
+        let mut total_bits = 0;
+
+        // Reserve space for the header
+        if !self.header_prepended {
+            total_bits += USABLE_BITS_PER_FIELD_ELEMENT;
+        }
+
+        // Reserve space for the length prefix
+        if self.prepend_length {
+            total_bits += Self::LENGTH_PREFIX_BITS;
+        }
+
+        // Reserve space for the data
+        total_bits += data.len() * 8;
+
+        // We can fit data into 31.75 bytes per FE, or 254 bits.
+        total_bits.div_ceil(USABLE_BITS_PER_FIELD_ELEMENT)
+    }
+
+    fn code(&mut self, builder: &mut PartialSidecar, data: &[u8]) {
+        // Prepend header only once
+        if !self.header_prepended {
+            let mut header_bits = Self::bytes_to_bits(self.get_name().as_bytes());
+
+            // Resize header, so it is exactly 254 bits (31.75 bytes) long
+            header_bits.resize(USABLE_BITS_PER_FIELD_ELEMENT, false);
+
+            let fe = Self::bits_to_field_elements(&header_bits)[0];
+            builder.ingest_valid_fe(WholeFe::new(&fe).unwrap());
+            self.header_prepended = true;
+        }
+
+        if data.is_empty() {
+            return;
+        }
+
+        let mut data_bits = vec![];
+        // Prepend length prefix if required
+        if self.prepend_length {
+            // Create length prefix (32 bits/4 bytes)
+            let length_prefix = (data.len() as u32).to_be_bytes();
+
+            // Convert data to bits, prepended with length
+            data_bits = Self::bytes_to_bits(&length_prefix);
+        }
+
+        // Append data
+        data_bits.extend(Self::bytes_to_bits(data));
+
+        // Convert bits to field elements
+        let fes = Self::bits_to_field_elements(&data_bits);
+
+        // Ingest each field element
+        for fe in fes {
+            builder.ingest_valid_fe(WholeFe::new(&fe).unwrap());
+        }
+    }
+
+    fn finish(self, _builder: &mut PartialSidecar) {}
+
+    fn decode_all(&mut self, blobs: &[Blob]) -> Option<Vec<Vec<u8>>> {
+        if blobs.is_empty() {
+            return None;
+        }
+
+        // Validate all field elements
+        if blobs
+            .iter()
+            .flat_map(|blob| blob.chunks(FIELD_ELEMENT_BYTES_USIZE).map(WholeFe::new))
+            .any(|fe| fe.is_none())
+        {
+            return None;
+        }
+
+        let mut fes = blobs.iter().flat_map(|blob| {
+            blob.chunks(FIELD_ELEMENT_BYTES_USIZE)
+                .map(WholeFe::new)
+                .map(|fe| fe.unwrap())
+        });
+
+        // Consume header FE
+        fes.next().unwrap();
+
+        let mut res = Vec::new();
+        loop {
+            match self.decode_one(&mut fes) {
+                Ok(Some(data)) => res.push(data),
+                Ok(None) => break,
+                Err(()) => return None,
+            }
+        }
+
+        Some(res)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_eips::eip4844::builder::SidecarBuilder;
+    use alloy_eips::eip4844::USABLE_BYTES_PER_BLOB;
+
+    #[test]
+    fn test_bits_conversion() {
+        let original = b"Hello, world!";
+        let bits = OptimizedBlobCoder::bytes_to_bits(original);
+        let bytes = OptimizedBlobCoder::bits_to_bytes(&bits);
+        assert_eq!(bytes, original);
+    }
+
+    #[test]
+    fn test_field_element_conversion() {
+        let original = vec![true, false, true, true, false, false, true, false];
+        let fes = OptimizedBlobCoder::bits_to_field_elements(&original);
+        let bits = OptimizedBlobCoder::field_elements_to_bits(&fes);
+
+        // We'll have padding bits, so just check the first 8 bits
+        assert_eq!(bits[0..8], original);
+    }
+
+    #[test]
+    fn test_header_name_encoding() {
+        let mut coder = OptimizedBlobCoder::new(true);
+        let mut builder = SidecarBuilder::from_coder_and_data(coder, &vec![0]);
+
+        let blobs = builder.take();
+        let header_fe = blobs[0].as_slice()[0..32].to_vec();
+        let header_bits = OptimizedBlobCoder::field_elements_to_bits(&[header_fe.try_into().unwrap()]);
+        let header_bytes = OptimizedBlobCoder::bits_to_bytes(&header_bits)
+            .into_iter()
+            .take_while(|&b| b != 0)
+            .collect::<Vec<_>>();
+        let header_name = String::from_utf8_lossy(&header_bytes);
+
+        assert_eq!(header_name, coder.get_name());
+    }
+
+    #[test]
+    fn test_various_data_sizes() {
+        // Test with different data sizes to ensure we handle edge cases correctly
+        let test_sizes = [
+            0, 1, 30, 31, 32, 33, 63, 64, 65, 127, 128, 129, 252, 253, 254, 255, 256, 257, 1000,
+            4096, 8192,
+        ];
+
+        for size in test_sizes {
+            let data = vec![255u8; size];
+            let mut coder = OptimizedBlobCoder::new(true);
+            let builder = SidecarBuilder::from_coder_and_data(coder, &data);
+
+            let blobs = builder.take();
+            let decoded = coder.decode_all(&blobs).unwrap();
+
+            assert_eq!(decoded.len(), if size == 0 { 0 } else { 1 });
+            if size > 0 {
+                assert_eq!(decoded[0], data);
+            }
+        }
+    }
+
+    #[test]
+    fn test_large_data() {
+        let data = vec![255u8; USABLE_BYTES_PER_BLOB + 1000];
+        let mut coder = OptimizedBlobCoder::new(true);
+        let builder = SidecarBuilder::from_coder_and_data(coder, &data);
+
+        let blobs = builder.take();
+        let decoded = coder.decode_all(&blobs).unwrap().concat();
+
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn test_31_75_byte_vector_of_ones_encodes_into_one_fe_no_prepended_length() {
+        // Create a 31.75-byte vector with all bits set to 1
+        let mut data = vec![255u8; 31];
+        // Set the last byte to 252 (11111100 in binary)
+        data.push(252u8);
+
+        let mut coder = OptimizedBlobCoder::new(false);
+        let builder = SidecarBuilder::from_coder_and_data(coder, &data);
+        let blobs = builder.take();
+
+        let decoded = coder.decode_all(&blobs);
+
+        // Check that only first 32 bytes of data are non-zero (skip header)
+        let first_32_bytes = blobs[0].as_slice()[32..64].to_vec();
+        assert_eq!(first_32_bytes[0], 63); // First byte should be 63 (00111111)
+        assert_eq!(first_32_bytes[1..32], vec![255; 31]); // All other bytes should be 255
+
+        // All other bytes should be zero
+        for byte in blobs[0].as_slice()[64..].iter() {
+            assert_eq!(*byte, 0);
+        }
+    }
+
+    #[test]
+    fn test_max_data_size_no_prepended_length() {
+        let max_usable_bytes = USABLE_BYTES_PER_BLOB - 32; // Subtract 32 bytes for the header
+        let data = vec![255u8; max_usable_bytes];
+        let mut coder = OptimizedBlobCoder::new(false);
+        let builder = SidecarBuilder::from_coder_and_data(coder, &data);
+
+        let blobs = builder.take();
+        let decoded = coder.decode_all(&blobs).unwrap().concat();
+
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn test_blob_overflow_no_prepended_length() {
+        let max_usable_bytes = USABLE_BYTES_PER_BLOB - 32; // Subtract 32 bytes for the header
+        let overflow_bytes_count = 150;
+        let data = vec![255u8; max_usable_bytes + overflow_bytes_count];
+        let mut coder = OptimizedBlobCoder::new(false);
+        let builder = SidecarBuilder::from_coder_and_data(coder, &data);
+
+        let blobs = builder.take();
+        let decoded = coder.decode_all(&blobs).unwrap().concat();
+
+        // Add 32 for the header (present only in the first FE)
+        // Subtract bytes of data that overflowed
+        let zeros_count = max_usable_bytes + 32 - overflow_bytes_count;
+
+        assert_eq!(decoded[0..data.len()], data);
+        assert_eq!(decoded[data.len()..], vec![0u8; zeros_count]);
+    }
+}

--- a/src/submission/optimized_blob_coder.rs
+++ b/src/submission/optimized_blob_coder.rs
@@ -1,7 +1,6 @@
 use alloy_eips::eip4844::builder::{PartialSidecar, SidecarCoder};
 use alloy_eips::eip4844::utils::WholeFe;
 use alloy_eips::eip4844::{Blob, FIELD_ELEMENT_BYTES_USIZE, USABLE_BITS_PER_FIELD_ELEMENT};
-use alloy_primitives::hex::ToHexExt;
 
 /// Optimized BLOB coder that uses up to 254 bits (31.75 bytes) of each field element.
 ///
@@ -27,8 +26,10 @@ pub struct OptimizedBlobCoder {
 }
 
 impl OptimizedBlobCoder {
-    const UNALLOCATED_BITS_PER_FE: usize = 256 - USABLE_BITS_PER_FIELD_ELEMENT;
-    const LENGTH_PREFIX_BITS: usize = 32;
+    pub const UNALLOCATED_BITS_PER_FE: usize = 256 - USABLE_BITS_PER_FIELD_ELEMENT;
+    pub const LENGTH_PREFIX_BITS: usize = 32;
+    pub const HEADER_SIZE_BYTES: usize = 32; // 32 bytes for the header
+    pub const LENGTH_PREFIX_SIZE_BYTES: usize = Self::LENGTH_PREFIX_BITS / 8;
 
     /// Create a new instance of `OptimizedCoder`.
     pub fn new(prepend_length: bool) -> Self {
@@ -46,6 +47,11 @@ impl OptimizedBlobCoder {
             "Coder name must fit into 31 bytes (so it's encoded as one FE)"
         );
         NAME
+    }
+
+    /// Check if the coder should prepend a length prefix to the data.
+    pub fn should_prepend_length(&self) -> bool {
+        self.prepend_length
     }
 
     /// Decode a single piece of data from an iterator of valid field elements.
@@ -69,7 +75,7 @@ impl OptimizedBlobCoder {
 
         // Set up initial values
         const MAX_ALLOCATION_SIZE: usize = 2_097_152; // 2 MiB
-        let mut num_bytes = 0;
+        let mut num_bytes;
         let mut start_bit = 0;
 
         // Read data length
@@ -343,12 +349,13 @@ mod tests {
 
     #[test]
     fn test_header_name_encoding() {
-        let mut coder = OptimizedBlobCoder::new(true);
-        let mut builder = SidecarBuilder::from_coder_and_data(coder, &vec![0]);
+        let coder = OptimizedBlobCoder::new(true);
+        let builder = SidecarBuilder::from_coder_and_data(coder, &vec![0]);
 
         let blobs = builder.take();
         let header_fe = blobs[0].as_slice()[0..32].to_vec();
-        let header_bits = OptimizedBlobCoder::field_elements_to_bits(&[header_fe.try_into().unwrap()]);
+        let header_bits =
+            OptimizedBlobCoder::field_elements_to_bits(&[header_fe.try_into().unwrap()]);
         let header_bytes = OptimizedBlobCoder::bits_to_bytes(&header_bits)
             .into_iter()
             .take_while(|&b| b != 0)
@@ -400,11 +407,9 @@ mod tests {
         // Set the last byte to 252 (11111100 in binary)
         data.push(252u8);
 
-        let mut coder = OptimizedBlobCoder::new(false);
+        let coder = OptimizedBlobCoder::new(false);
         let builder = SidecarBuilder::from_coder_and_data(coder, &data);
         let blobs = builder.take();
-
-        let decoded = coder.decode_all(&blobs);
 
         // Check that only first 32 bytes of data are non-zero (skip header)
         let first_32_bytes = blobs[0].as_slice()[32..64].to_vec();

--- a/src/submission/rpc_submitter.rs
+++ b/src/submission/rpc_submitter.rs
@@ -160,15 +160,14 @@ impl RpcSubmitter {
         fee_history: FeeHistory,
     ) -> TransactionRequest {
         let mut partial_blobs = partial_blobs.clone();
-        // TODO: Sort to submit only the best partial blobs
-        // partial_blobs.sort();
+        partial_blobs.sort();
 
         if partial_blobs.len() > MAX_BLOBS_PER_BLOCK {
             partial_blobs.truncate(MAX_BLOBS_PER_BLOCK);
         }
 
         // Immediately signal partial blobs are being submitted
-        self.submitted_partial_blobs_sender
+        let _ = self.submitted_partial_blobs_sender
             .send(partial_blobs.clone())
             .await;
 
@@ -412,6 +411,7 @@ mod tests {
                 },
             ],
             partial_blob_data,
+            0,
         );
 
         // Create sidecar and solidity structs
@@ -456,6 +456,7 @@ mod tests {
                 metadata: Default::default(),
             }],
             data,
+            0,
         )
     }
 }

--- a/src/submission/rpc_submitter.rs
+++ b/src/submission/rpc_submitter.rs
@@ -1,13 +1,13 @@
 use crate::building::blob_aggregator::AggregationContext;
 use crate::building::partial_blob::PartialBlob;
-use alloy_eips::eip4844::builder::{SidecarBuilder, SimpleCoder};
-use alloy_eips::eip4844::MAX_BLOBS_PER_BLOCK;
+use crate::submission::optimized_blob_coder::OptimizedBlobCoder;
+use crate::submission::rpc_submitter::IBlobReceiver::BlobSegment;
+use alloy_eips::eip4844::builder::SidecarBuilder;
+use alloy_eips::eip4844::{BlobTransactionSidecar, MAX_BLOBS_PER_BLOCK, USABLE_BYTES_PER_BLOB};
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{Address, Bytes};
-use alloy_provider::network::{
-    AnyNetwork, EthereumWallet, NetworkWallet, TransactionBuilder, TransactionBuilder4844,
-};
-use alloy_provider::{Provider, ProviderBuilder, SendableTx};
+use alloy_provider::network::{EthereumWallet, TransactionBuilder, TransactionBuilder4844};
+use alloy_provider::{Provider, ProviderBuilder, SendableTx, WalletProvider};
 use alloy_rpc_types_eth::{FeeHistory, TransactionRequest};
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::{sol, SolCall};
@@ -125,10 +125,7 @@ impl RpcSubmitter {
             .unwrap();
 
         // Create Blob TxRequest to be submitted
-        let signer_address: Address =
-            <EthereumWallet as NetworkWallet<AnyNetwork>>::default_signer_address(
-                &self.ethereum_wallet,
-            );
+        let signer_address: Address = provider.default_signer_address();
         let tx_request = self
             .create_tx(partial_blobs.clone(), fee_history)
             .await
@@ -175,45 +172,12 @@ impl RpcSubmitter {
             .send(partial_blobs.clone())
             .await;
 
-        // Create BlobTransactionSidecar and BlobSegments data to be included in the transaction
-        let mut sidecar: SidecarBuilder<SimpleCoder> =
-            SidecarBuilder::with_capacity(partial_blobs.len());
-        let mut blob_segments = vec![];
-        partial_blobs.iter().for_each(|partial_blob| {
-            let partial_blob_data = partial_blob.data().clone();
-
-            let mut index: u64 = 0;
-            partial_blob.segments().iter().for_each(|segment| {
-                let length = segment.blob_segment_data.len() as u64;
-                blob_segments.push(IBlobReceiver::BlobSegment {
-                    receiverAddress: Default::default(),
-                    firstBlobIndex: 0,
-                    numBlobs: 0,
-                    offset: index,
-                    length: length - 1,
-                    payload: Default::default(),
-                    blobHash: segment.hash,
-                });
-                index += length;
-            });
-
-            //TODO: Hack to satisfy SimpleCoder
-            let diff = 126976 - 31 - partial_blob_data.len();
-            let empty_bytes = vec![0u8; diff];
-            let mut partial_blob_data_vec = partial_blob_data.to_vec();
-            partial_blob_data_vec.extend_from_slice(&empty_bytes);
-
-            let full_blob_data = Bytes::from(partial_blob_data_vec);
-            sidecar.ingest(&full_blob_data);
-        });
-
-        // TODO: Remove expect
-        let sidecar = sidecar
-            .build()
-            .expect("Failed to create BlobTransactionSidecar");
+        // Create sidecar and Solidity structs
+        let (sidecar, blob_segments) =
+            RpcSubmitter::create_sidecar_and_solidity_structs(partial_blobs);
         let data = BlobSplitter::postBlobCall::new((blob_segments,)).abi_encode();
 
-        // Adjust execution priority fee, as this is the ordering criteria in GETH
+        // Adjust execution priority fee, as this is the ordering criteria of blob transactions
         let rewards = fee_history.reward.unwrap();
         let priority_fee = rewards.get(0).unwrap().get(0).unwrap().clone();
         let max_fee = priority_fee + fee_history.base_fee_per_gas.last().unwrap();
@@ -227,8 +191,271 @@ impl RpcSubmitter {
             .with_input(data)
     }
 
+    fn create_sidecar_and_solidity_structs(
+        partial_blobs: Vec<PartialBlob>,
+    ) -> (BlobTransactionSidecar, Vec<BlobSegment>) {
+        // Create BlobTransactionSidecar and BlobSegments data to be included in the transaction
+        let coder = OptimizedBlobCoder::new(true);
+        let mut sidecar = SidecarBuilder::from_coder_and_capacity(coder, partial_blobs.len());
+        let mut blob_segments = vec![];
+        partial_blobs
+            .iter()
+            .enumerate()
+            .for_each(|(i, partial_blob)| {
+                let partial_blob_data = partial_blob.data().clone();
+
+                // Create BlobSegment structs for Solidity contract call
+                let mut offset: u64 = 0;
+                partial_blob.segments().iter().for_each(|segment| {
+                    let length = segment.blob_segment_data.len() as u64;
+                    blob_segments.push(BlobSegment {
+                        receiverAddress: segment.callback_contract.unwrap_or_default(),
+                        firstBlobIndex: i as u64,
+                        numBlobs: 1,
+                        offset,
+                        length,
+                        payload: segment.callback_payload.clone().unwrap_or_default(),
+                        blobHash: segment.hash,
+                    });
+                    offset += length;
+                });
+
+                // Pad remaining blob space with zeros, so we fill the whole blob
+                let mut diff = USABLE_BYTES_PER_BLOB as i64;
+                diff -= partial_blob_data.len() as i64; // Subtract blob data length
+
+                // Subtract header size
+                if i == 0 {
+                    diff -= OptimizedBlobCoder::HEADER_SIZE_BYTES as i64;
+                }
+
+                // Subtract blob length size
+                if coder.should_prepend_length() {
+                    diff -= OptimizedBlobCoder::LENGTH_PREFIX_SIZE_BYTES as i64;
+                }
+
+                // Handle negative diff, which means more than one blob is needed
+                if diff < 0 {
+                    diff += USABLE_BYTES_PER_BLOB as i64;
+                }
+
+                let empty_bytes = vec![0u8; diff as usize];
+                let mut partial_blob_data_vec = partial_blob_data.to_vec();
+                partial_blob_data_vec.extend_from_slice(&empty_bytes);
+
+                // Create & ingest full blob data
+                let full_blob_data = Bytes::from(partial_blob_data_vec);
+                sidecar.ingest(&full_blob_data);
+            });
+
+        // TODO: Remove expect
+        let sidecar = sidecar
+            .build()
+            .expect("Failed to create BlobTransactionSidecar");
+
+        (sidecar, blob_segments)
+    }
+
     /// Get clone of the sender channel for submitted partial blobs.
     pub fn get_partial_blobs_sender(&self) -> mpsc::Sender<Vec<PartialBlob>> {
         self.partial_blobs_sender.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::building::partial_blob::PartialBlob;
+    use crate::primitives::blob_segment::BlobSegment;
+    use crate::submission::optimized_blob_coder::OptimizedBlobCoder;
+    use crate::submission::rpc_submitter::RpcSubmitter;
+    use alloy_eips::eip4844::USABLE_BYTES_PER_BLOB;
+    use alloy_primitives::{Bytes, FixedBytes, U256};
+
+    #[test]
+    fn test_fully_pack_one_blob() {
+        let mut length = USABLE_BYTES_PER_BLOB;
+        length -= OptimizedBlobCoder::HEADER_SIZE_BYTES;
+        length -= OptimizedBlobCoder::LENGTH_PREFIX_SIZE_BYTES;
+
+        // Create a blob with data
+        let partial_blob_data = Bytes::from(vec![255u8; length]);
+        let partial_blob = create_partial_blob(partial_blob_data);
+
+        // Create sidecar and solidity structs
+        let (sidecar, blob_segments) =
+            RpcSubmitter::create_sidecar_and_solidity_structs(vec![partial_blob]);
+
+        // Assert there is only one blob with 1 segment
+        assert_eq!(sidecar.blobs.len(), 1);
+        assert_eq!(blob_segments.len(), 1);
+
+        // Assert all field elements are greater than zero
+        let field_elements_as_u256 = sidecar.blobs[0]
+            .chunks(32) // U256 is 32 bytes (256 bits)
+            .map(|chunk| FixedBytes::from_slice(chunk).into())
+            .collect::<Vec<U256>>();
+        assert!(field_elements_as_u256.iter().all(|fe| *fe > U256::ZERO));
+    }
+
+    #[test]
+    fn test_fully_pack_two_blobs() {
+        let mut length = USABLE_BYTES_PER_BLOB;
+        length -= OptimizedBlobCoder::HEADER_SIZE_BYTES;
+        length -= OptimizedBlobCoder::LENGTH_PREFIX_SIZE_BYTES;
+
+        // Create a blob with data
+        let partial_blob_data_1 = Bytes::from(vec![255u8; length]);
+        let partial_blob_1 = create_partial_blob(partial_blob_data_1);
+
+        length += OptimizedBlobCoder::HEADER_SIZE_BYTES; // Header is present only in the first blob
+        let partial_blob_data_2 = Bytes::from(vec![255u8; length]);
+        let partial_blob_2 = create_partial_blob(partial_blob_data_2);
+
+        // Create sidecar and solidity structs
+        let (sidecar, blob_segments) =
+            RpcSubmitter::create_sidecar_and_solidity_structs(vec![partial_blob_1, partial_blob_2]);
+
+        // Assert there are two blobs with 1 segment each
+        assert_eq!(sidecar.blobs.len(), 2);
+        assert_eq!(blob_segments.len(), 2);
+
+        // Assert ALL field elements of BLOB 1 are greater than zero
+        let field_elements_as_u256 = sidecar.blobs[0]
+            .chunks(32) // U256 is 32 bytes (256 bits)
+            .map(|chunk| FixedBytes::from_slice(chunk).into())
+            .collect::<Vec<U256>>();
+        assert!(field_elements_as_u256.iter().all(|fe| *fe > U256::ZERO));
+
+        // Assert ALL field elements of BLOB 2 are greater than zero
+        let field_elements_as_u256 = sidecar.blobs[1]
+            .chunks(32) // U256 is 32 bytes (256 bits)
+            .map(|chunk| FixedBytes::from_slice(chunk).into())
+            .collect::<Vec<U256>>();
+        assert!(field_elements_as_u256.iter().all(|fe| *fe > U256::ZERO));
+    }
+
+    #[test]
+    fn test_pad_first_blob() {
+        let mut length = 31;
+        length -= OptimizedBlobCoder::LENGTH_PREFIX_SIZE_BYTES;
+
+        // Create a blob with data
+        let partial_blob_data_1 = Bytes::from(vec![255u8; length]);
+        let partial_blob_1 = create_partial_blob(partial_blob_data_1);
+
+        length = USABLE_BYTES_PER_BLOB;
+        length -= OptimizedBlobCoder::LENGTH_PREFIX_SIZE_BYTES;
+        let partial_blob_data_2 = Bytes::from(vec![255u8; length]);
+        let partial_blob_2 = create_partial_blob(partial_blob_data_2);
+
+        // Create sidecar and solidity structs
+        let (sidecar, blob_segments) =
+            RpcSubmitter::create_sidecar_and_solidity_structs(vec![partial_blob_1, partial_blob_2]);
+
+        // Assert there are two blobs with 1 segment each
+        assert_eq!(sidecar.blobs.len(), 2);
+        assert_eq!(blob_segments.len(), 2);
+
+        // Assert ONLY FIRST TWO field element of BLOB 2 is greater than zero and the rest are zero
+        let field_elements_as_u256 = sidecar.blobs[0]
+            .chunks(32) // U256 is 32 bytes (256 bits)
+            .map(|chunk| FixedBytes::from_slice(chunk).into())
+            .collect::<Vec<U256>>();
+        assert!(field_elements_as_u256[0] > U256::ZERO);
+        assert!(field_elements_as_u256[1] > U256::ZERO);
+        assert!(field_elements_as_u256[2..]
+            .iter()
+            .all(|fe| *fe == U256::ZERO));
+
+        // Assert ALL field elements of BLOB 2 are greater than zero
+        let field_elements_as_u256 = sidecar.blobs[1]
+            .chunks(32) // U256 is 32 bytes (256 bits)
+            .map(|chunk| FixedBytes::from_slice(chunk).into())
+            .collect::<Vec<U256>>();
+        assert!(field_elements_as_u256.iter().all(|fe| *fe > U256::ZERO));
+    }
+
+    #[test]
+    fn test_overflow_into_two_blobs() {
+        let mut length = USABLE_BYTES_PER_BLOB;
+        length -= OptimizedBlobCoder::HEADER_SIZE_BYTES;
+        length -= OptimizedBlobCoder::LENGTH_PREFIX_SIZE_BYTES;
+        length += 1; // Add 1 byte to overflow into the second blob
+
+        // Create a blob with data
+        let partial_blob_data = Bytes::from(vec![254u8; length]);
+        let partial_blob = PartialBlob::new(
+            vec![
+                BlobSegment {
+                    block: None,
+                    min_timestamp: None,
+                    max_timestamp: None,
+                    max_blob_segment_fee: 0,
+                    blob_segment_data: partial_blob_data.clone().slice(0..(length - 1)),
+                    callback_contract: None,
+                    callback_payload: None,
+                    hash: Default::default(),
+                    uuid: Default::default(),
+                    metadata: Default::default(),
+                },
+                BlobSegment {
+                    block: None,
+                    min_timestamp: None,
+                    max_timestamp: None,
+                    max_blob_segment_fee: 0,
+                    blob_segment_data: partial_blob_data.clone().slice(length - 1..length),
+                    callback_contract: None,
+                    callback_payload: None,
+                    hash: Default::default(),
+                    uuid: Default::default(),
+                    metadata: Default::default(),
+                },
+            ],
+            partial_blob_data,
+        );
+
+        // Create sidecar and solidity structs
+        let (sidecar, blob_segments) =
+            RpcSubmitter::create_sidecar_and_solidity_structs(vec![partial_blob]);
+
+        // Assert there are two blobs with two segments
+        assert_eq!(sidecar.blobs.len(), 2);
+        assert_eq!(blob_segments.len(), 2);
+
+        // Assert ALL field elements of BLOB 1 are greater than zero
+        let field_elements_as_u256 = sidecar.blobs[0]
+            .chunks(32) // U256 is 32 bytes (256 bits)
+            .map(|chunk| FixedBytes::from_slice(chunk).into())
+            .collect::<Vec<U256>>();
+        assert!(field_elements_as_u256.iter().all(|fe| *fe > U256::ZERO));
+
+        // Assert ONLY FIRST field element of BLOB 2 is greater than zero and the rest are zero
+        let field_elements_as_u256 = sidecar.blobs[1]
+            .chunks(32) // U256 is 32 bytes (256 bits)
+            .map(|chunk| FixedBytes::from_slice(chunk).into())
+            .collect::<Vec<U256>>();
+
+        assert!(field_elements_as_u256[0] > U256::ZERO);
+        assert!(field_elements_as_u256[1..]
+            .iter()
+            .all(|fe| *fe == U256::ZERO));
+    }
+
+    fn create_partial_blob(data: Bytes) -> PartialBlob {
+        PartialBlob::new(
+            vec![BlobSegment {
+                block: None,
+                min_timestamp: None,
+                max_timestamp: None,
+                max_blob_segment_fee: 0,
+                blob_segment_data: data.clone(),
+                callback_contract: None,
+                callback_payload: None,
+                hash: Default::default(),
+                uuid: Default::default(),
+                metadata: Default::default(),
+            }],
+            data,
+        )
     }
 }


### PR DESCRIPTION
Optimized BLOB coder that uses up to **254 bits** (31.75 bytes) of each field element.

This coder maximizes storage efficiency by using:
- The lower **254 bits** of each field element (31.75 bytes)
- The **top 2 bits** of each field element **must remain 0** to preserve EIP-4844 KZG commitment requirements

        The BLS12-381 scalar field (used in KZG commitments) has a modulus close to 2^255.
        However, it is not exactly 2^255, so the top 2 bits of the field element must be 0.
        This ensures the field element remains valid.

Encoding process:
- Before encoding data, the **HEADER** (blob coder identifier) is encoded into the first field element of the first blob
- Data is _OPTIONALLY_ pre-pended with a **32-bit** (4 bytes) big-endian length prefix
- **Data is converted to a bitstream** and packed into consecutive field elements
- **Each field element stores up to 254 bits of the stream**
- The **last field element is padded with zeros** if needed